### PR TITLE
chore: add tailwind debug screens

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,6 +28,7 @@
     "react": "18.2.0",
     "react-dom": "18.2.0",
     "superjson": "1.12.3",
+    "tailwindcss-debug-screens": "^2.2.1",
     "ts-invariant": "^0.10.3",
     "wagmi": "^0.12.13",
     "zod": "^3.21.4"

--- a/src/pages/_document.tsx
+++ b/src/pages/_document.tsx
@@ -1,11 +1,19 @@
+import classNames from "classnames";
 import { Html, Head, Main, NextScript } from "next/document";
+
+import { env } from "~/env.mjs";
 
 export default function Document() {
   return (
     <Html>
       <Head />
       <body>
-        <div className="bg-ivory">
+        <div
+          className={classNames(
+            "bg-ivory",
+            env.NODE_ENV === "development" && "debug-screens"
+          )}
+        >
           <Main />
           <NextScript />
         </div>

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -10,5 +10,8 @@ export default {
       },
     },
   },
-  plugins: [require("@tailwindcss/forms")],
+  plugins: [
+    require("@tailwindcss/forms"),
+    require("tailwindcss-debug-screens"),
+  ],
 } satisfies Config;

--- a/yarn.lock
+++ b/yarn.lock
@@ -4958,6 +4958,11 @@ synckit@^0.8.5:
     "@pkgr/utils" "^2.3.1"
     tslib "^2.5.0"
 
+tailwindcss-debug-screens@^2.2.1:
+  version "2.2.1"
+  resolved "https://registry.yarnpkg.com/tailwindcss-debug-screens/-/tailwindcss-debug-screens-2.2.1.tgz#8dd0854a273daa4f30f4c383370872c6bca337cd"
+  integrity sha512-EMyA0CYBzqcZJHtVDvBfmYzfx3NxuK4qDyVO5wnzcGOrmJsv25D9xPpWefVTORTvhE6pCh90Z1WYnLUKsg3yMw==
+
 tailwindcss@^3.3.2:
   version "3.3.2"
   resolved "https://registry.yarnpkg.com/tailwindcss/-/tailwindcss-3.3.2.tgz#2f9e35d715fdf0bbf674d90147a0684d7054a2d3"


### PR DESCRIPTION
This PR adds [`tailwindcss-debug-screens`](https://www.npmjs.com/package/tailwindcss-debug-screens), a utility to help debug Tailwind screen sizes in development.